### PR TITLE
delete all trailing spaces

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,5 @@
 --title Crichton Representors Documentation
---verbose 
---no-private 
+--verbose
+--no-private
 --output-dir ./yardoc
 'lib/**/*.rb' - '*.md'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Crichton Representors
 [![Build Status](https://travis-ci.org/mdsol/crichton-representors.svg)](https://travis-ci.org/mdsol/crichton-representors)
-[Crichton][] Representors is a library to simplify Hypermedia message representation. It has the knowledge of Hypermedia 
+[Crichton][] Representors is a library to simplify Hypermedia message representation. It has the knowledge of Hypermedia
 media-types from the Ancients!
 
 NOTE: THIS IS UNDER HEAVY DEV AND IS NOT READY TO BE USED YET
 
-A Crichton::Representor exposes a simple state-machine interface that simplifies generating, translating, introspecting 
-and manipulating Hypermedia messages. 
+A Crichton::Representor exposes a simple state-machine interface that simplifies generating, translating, introspecting
+and manipulating Hypermedia messages.
 
 ## Contributing
 See [CONTRIBUTING][] for details.

--- a/crichton-representors.gemspec
+++ b/crichton-representors.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = <<-DESC
     Crichton Representors is a library to simplify Hypermedia message representation.
   DESC
-  
+
   s.add_dependency('enumerable-lazy', '~> 0.0.1') if RUBY_VERSION < '2.0'
   s.add_dependency('rake')
 end

--- a/lib/crichton/field.rb
+++ b/lib/crichton/field.rb
@@ -10,7 +10,7 @@ module Crichton
     SCOPE_KEY = :scope
     NAME_KEY = :name
     DEFAULT_SCOPE = 'attribute'
-    
+
     # @example
     #   hash =  {field_name: {field_property: property_name}}
     #   Fields.new(hash)
@@ -25,22 +25,22 @@ module Crichton
     SIMPLE_METHODS.each do |meth|
       define_method(meth) { @field_hash[meth] }
     end
-    
+
     # @return [String] representing the sort of field
     def scope
       @scope ||= @field_hash[SCOPE_KEY] || DEFAULT_SCOPE
     end
-    
+
     # @return [Hash] The hash representation of the object
     def to_hash
       @to_hash ||= { @field_hash[NAME_KEY] => @field_hash.reject {|k,v| k == NAME_KEY } }
     end
-    
-    # @return [String] the yaml representation of the object 
+
+    # @return [String] the yaml representation of the object
     def to_yaml
       @to_yaml ||= YAML.dump(to_hash)
-    end    
-    
+    end
+
     # @return [Array] who's elements are all [Hash] objects
     def validators
       @validators ||= if @field_hash.has_key?(VALIDATORS_KEY)
@@ -49,12 +49,12 @@ module Crichton
         []
       end
     end
-    
+
     # @return [Array] who's elements are all Crichton::Options objects
     def options
       @options ||= Crichton::Options.new(@field_hash[OPTIONS_KEY], name)
     end
-    
+
     # @returns the value of the field
     def call
       value

--- a/lib/crichton/options.rb
+++ b/lib/crichton/options.rb
@@ -9,13 +9,13 @@ module Crichton
     DEFAULT_TYPE = :list
     ID_KEY = :id
     ID_TEMPLATE = "%s_options"
-    
+
     # @param [Hash] the abstract representation of Field Options
     def initialize(options_hash = {}, field_name = '')
       @options_hash = options_hash || {}
       @field_name = field_name
     end
-  
+
     # @return [String] delineating the Options type
     def type
       @type ||= begin
@@ -23,27 +23,27 @@ module Crichton
         type_keys || DEFAULT_TYPE
       end
     end
-    
+
     # @return [Bool] indicating whether the Options can be treated as a datalist
     def datalist?
       type == :external || @options_hash.has_key?(ID_KEY)
     end
-    
+
     # @return [String] representing a unique id for the options
     def id
         @options_hash[ID_KEY] || ID_TEMPLATE % @field_name
     end
-    
+
     # @return [Hash] version of the Options
     def as_hash
       type == :list ? Hash[@options_hash[:list].map { |x| [x.to_sym, x] }] : @options_hash[type]
-    end    
-    
+    end
+
     # @return [Array] hash keys
     def keys
       as_hash.keys
     end
-    
+
     # @return [Array] hash values
     def values
       as_hash.values

--- a/lib/crichton/representor.rb
+++ b/lib/crichton/representor.rb
@@ -16,20 +16,20 @@ module Crichton
     UNKNOWN_PROTOCOL = 'ruby_id'
     DEFAULT_PROTOCOL = 'http'
     PROTOCOL_TEMPLATE = "%s://%s"
-    
-    
+
+
     # @param representor_hash [Hash] the abstract representor hash defining a resource
     def initialize(representor_hash = nil)
       @representor_hash = representor_hash || {}
     end
-    
+
     # Returns the documentfor the representor
     #
     # @return [String] the document for the representor
     def doc
       @doc ||= @representor_hash[DOC_KEY] || ''
     end
-    
+
     # The URI for the object
     #
     # @note If the URI can't be made from the provided information it constructs one fromt the Ruby ID
@@ -41,33 +41,33 @@ module Crichton
         PROTOCOL_TEMPLATE % [protocol, uri]
       end
     end
-    
+
     # @return [Hash] The hash representation of the object
     def to_hash
       @to_hash ||= @representor_hash
     end
-    
-    # @return [String] the yaml representation of the object 
+
+    # @return [String] the yaml representation of the object
     def to_yaml
       @to_yaml ||= YAML.dump(@representor_hash)
     end
-    
+
     # @return [Hash] the resource attributes inferred from representor[:semantics]
     def properties
       @properties ||= Hash[(@representor_hash[SEMANTIC_KEY] || {}).map { |k, v| [ k, v[VALUE_KEY]] }]
     end
-    
+
     # @return [Enumerable] who's elements are all <Crichton:Representor> objects
     def embedded
       @embedded ||= (@representor_hash[EMBEDDED_KEY] || []).lazy.map { |embed|  Representor.new(embed) }
     end
-    
+
     # @return [Array] who's elements are all <Crichton:Transition> objects
     def meta_links
       @meta_links ||= get_transitions((@representor_hash[META_KEY] || []).map { |k, v| { k => { href: v } } })
     end
-    
-    # @return [Array] who's elements are all <Crichton:Transition> objects    
+
+    # @return [Array] who's elements are all <Crichton:Transition> objects
     def transitions
       @transitions ||= begin
         transitions = (@representor_hash[TRANSITION_KEY] || []).map { |k, v| {k => v} }
@@ -75,7 +75,7 @@ module Crichton
       end
     end
 
-    # @return [Array] who's elements are all <Crichton:Option> objects    
+    # @return [Array] who's elements are all <Crichton:Option> objects
     def datalists
       @datalists ||= begin
         attributes = transitions.map { |transition| transition.attributes }
@@ -85,10 +85,10 @@ module Crichton
         options.select { |o| o.datalist? }
       end
     end
-    
+
     private
-    
-    def get_transitions(hash)  
+
+    def get_transitions(hash)
       hash.map { |h| Crichton::Transition.new(h) }
     end
   end

--- a/lib/crichton/representor/version.rb
+++ b/lib/crichton/representor/version.rb
@@ -6,7 +6,7 @@ unless defined?(::Crichton::Representor::VERSION)
         MAJOR = 0
         MINOR = 0
         TINY  = 1
-    
+
         STRING = [MAJOR, MINOR, TINY].join('.')
       end
     end

--- a/lib/crichton/transition.rb
+++ b/lib/crichton/transition.rb
@@ -11,7 +11,7 @@ module Crichton
     PARAMETER_FIELDS = 'url'
     ATTRIBUTE_FIELDS = 'attribute'
     URL_TEMPLATE = "%s{?%s}"
-  
+
     # @example
     #   hash =  {rel: {link_property: property_name}}
     #   Transition.new(hash)
@@ -23,18 +23,18 @@ module Crichton
       @transition_hash = transition_hash[rel].dup
       @transition_hash[REL_KEY] = rel
     end
-    
+
     # @return [String] The name of the Relationship
     def rel
       @transition_hash[REL_KEY]
     end
-    
+
     # @return [String] The URI for the object
     def uri
       @transition_hash[HREF_KEY]
     end
-    
-    
+
+
     # TODO: Figure out how to scope differently
     # @return [String] The URI for the object templated against #parameters
     def templated_uri
@@ -44,39 +44,39 @@ module Crichton
         URL_TEMPLATE % [uri, parameters.map { |p| p.name }.join(",")]
       end
     end
-    
+
     def templated?
       templated_uri != uri
     end
-    
+
     # @return [Array] who's elements are all <Crichton:Transition> objects
     def meta_links
-      meta_links ||= (@transition_hash[LINKS_KEY] || []).map do |link_key, link_href| 
-        Transition.new( { link_key => { href: link_href } } ) 
+      meta_links ||= (@transition_hash[LINKS_KEY] || []).map do |link_key, link_href|
+        Transition.new( { link_key => { href: link_href } } )
       end
     end
-    
+
     # @return [String] representing the Uniform Interface Method
     def interface_method
       @interface_method ||= @transition_hash[METHOD_KEY] || DEFAULT_METHOD
-    end    
-    
+    end
+
     # The Parameters (i.e. GET variables)
     #
     # @return [Array] who's elements are all <Crichton:Field> objects
     def parameters
       @parameters ||= get_field_by_type(PARAMETER_FIELDS)
-    end    
+    end
 
     # The Parameters (i.e. POST variables)
     #
-    # @return [Array] who's elements are all <Crichton:Field> objects    
+    # @return [Array] who's elements are all <Crichton:Field> objects
     def attributes
       @attributes ||= get_field_by_type(ATTRIBUTE_FIELDS)
-    end        
-    
+    end
+
     private
-    
+
     def descriptor_fields(hash)
       hash[DESCRIPTORS_KEY].map { |k, v| Field.new({k => v }) }
     end
@@ -84,9 +84,9 @@ module Crichton
     def filtered_fields(fields, scope)
       fields.select { |field| field.scope == scope }
     end
-    
+
     def get_field_by_type(field_type)
-      fields = @transition_hash.has_key?(DESCRIPTORS_KEY) ? descriptor_fields(@transition_hash): []     
+      fields = @transition_hash.has_key?(DESCRIPTORS_KEY) ? descriptor_fields(@transition_hash): []
       filtered_fields(fields, field_type)
     end
   end

--- a/spec/lib/crichton/field_spec.rb
+++ b/spec/lib/crichton/field_spec.rb
@@ -15,27 +15,27 @@ module Crichton
         }
       }
     end
-    
+
     let(:field_hash) { @field_hash }
-    let(:subject) { Field.new(field_hash) }  
-    
+    let(:subject) { Field.new(field_hash) }
+
     describe '.new' do
       it 'returns a Crichton::Field instance' do
         expect(subject).to be_an_instance_of(Crichton::Field)
       end
-    
+
       describe '#to_hash' do
         it 'returns its constructor hash' do
           expect(subject.to_hash).to eq(field_hash)
         end
       end
-    
+
       describe '#name' do
         it 'returns the key when requesting the name' do
           expect(subject.name).to eq(field_hash.keys.first)
         end
       end
-      
+
       %w(value default description type data_type).map(&:to_sym).each do |key|
         describe "\##{key}" do
           it "returns it's hash value" do
@@ -43,40 +43,40 @@ module Crichton
           end
         end
       end
-      
+
       describe '#options' do
         it 'returns an options object' do
           @field_hash[:total_count][:options] = {}
           expect(subject.options).to be_an_instance_of(Options)
         end
-        
+
         it 'has a list interface even when a hash' do
           @field_hash[:total_count][:options] = { hash: {foo: 'bar', ninja: 'cow'} }
           expect(subject.options.as_list).to eq(field_hash[:total_count][:options][:hash].keys)
         end
-        
+
         it 'has a hash interface even when a list' do
           @field_hash[:total_count][:options] = { list: ['bar', 'cow'] }
           expect(subject.options.as_hash).to eq({bar: 'bar', cow: 'cow'})
         end
-        
+
         it 'has a hash interface when external' do
           @field_hash[:total_count][:options] = { external: {source: 'foo', target: 'bar'} }
           expect(subject.options.as_hash).to eq({source: 'foo', target: 'bar'})
         end
-        
+
         it 'defaults to a sensible id' do
            @field_hash[:total_count][:options] = { external: {source: 'foo', target: 'bar'} }
-           expect(subject.options.id).to eq('total_count_options')       
+           expect(subject.options.id).to eq('total_count_options')
         end
-        
+
         it 'gives back a passed in id' do
           @field_hash[:total_count][:options] = { list: ['bar', 'cow'], id: 'fortunes grace' }
           expect(subject.options.id).to eq('fortunes grace')
         end
-        
+
       end
-      
+
       describe '#validators' do
         it 'returns a list of hashes whose key is equal to the validator type' do
           validators = [{ max_length: 8 }, :required]
@@ -85,7 +85,7 @@ module Crichton
           object_keys = subject.validators.map { |hash| hash.keys.first }
           expect(object_keys).to eq(hash_keys)
         end
-        
+
         it 'returns a list of hashes whose value must be matched against' do
           validators = [{max_length: 8}, :required]
           @field_hash[:total_count][:validators] = validators
@@ -100,6 +100,6 @@ module Crichton
           expect(subject.()).to eq(@field_hash[:total_count][:value])
         end
       end
-    end    
+    end
   end
 end

--- a/spec/lib/crichton/representor_spec.rb
+++ b/spec/lib/crichton/representor_spec.rb
@@ -25,11 +25,11 @@ module Crichton
             value: '76ms'
           },
           brackreference: {
-            value: 886396728    
+            value: 886396728
           }
         }
       }
-      
+
       @transition_elements = {
         transitions: {
           self: {
@@ -62,13 +62,13 @@ module Crichton
       }
     end
     let(:representor_hash) { @representor_hash || @base_representor }
-    let(:subject) { Representor.new(representor_hash) }  
-     
+    let(:subject) { Representor.new(representor_hash) }
+
     describe '.new' do
       it 'returns a Crichton::Representor instance' do
         expect(subject).to be_an_instance_of(Crichton::Representor)
       end
-  
+
       it 'returns a Crichton::Representor instance with a nil argument' do
         expect(Representor.new).to be_an_instance_of(Crichton::Representor)
       end
@@ -79,30 +79,30 @@ module Crichton
           expect(subject.doc).to eq(representor_hash[:doc])
         end
       end
-      
+
       describe '#identifier' do
         it 'when given an href returns a url' do
           @representor_hash = {protocol: 'http', href: 'www.example.com/drds'}
           expect(subject.identifier).to match(URI::regexp)
         end
-        
+
         it 'when not given an href it returns ruby reference' do
           @representor_hash = {}
           expect(subject.identifier).to eq("ruby_id://%s" % subject.object_id)
         end
-      end     
+      end
 
       describe '#to_hash' do
         it 'returns a hash that it can be reconstructed with' do
           expect(Representor.new(subject.to_hash).to_hash).to eq(@base_representor)
         end
-      end  
+      end
 
       describe '#to_yaml' do
         it 'returns a yaml file that represents its internal hash' do
           expect(YAML.load(subject.to_yaml)).to eq(@base_representor)
         end
-      end        
+      end
 
       describe '#properties' do
         it 'returns a hash of attributes associated with the represented resource' do
@@ -113,33 +113,33 @@ module Crichton
           expect(semantic_elements_present).to be_true
          end
        end
-      
+
       describe '#embedded' do
         before do
           @count = 3
           @representor_hash = @base_representor.merge(@semantic_elements)
           @representor_hash[:embedded] = [@representor_hash.clone]*@count
         end
-        
+
         it 'returns a set of Representor objects' do
           expect(subject.embedded.first).to be_an_instance_of(Crichton::Representor)
         end
-        
+
         it 'returns a Representor objects that has its data' do
           embedded_objects_valid = subject.embedded.all? { |embed| embed.doc == representor_hash[:doc] }
           expect(embedded_objects_valid).to be_true
         end
-        
+
         it 'returns the all the Representors' do
           expect(subject.embedded.count).to eq(@count)
         end
-        
+
         it 'doesn\'t blow up even if nothing is embedded' do
           @representor_hash = @base_representor
           expect(subject.embedded.count).to eq(0)
         end
       end
-      
+
       describe '#transitions' do
         it 'returns all transitions' do
           @representor_hash =  @base_representor.merge(@transition_elements)
@@ -148,7 +148,7 @@ module Crichton
           expect(has_transitions).to be_true
         end
       end
-      
+
       describe '#meta_links' do
         it 'should return a list of transitions representing those links' do
           @base_representor[:links] = {
@@ -160,13 +160,13 @@ module Crichton
           expect(has_meta_link).to be_true
         end
       end
-      
+
       describe '#datalists' do
         it 'returns all paramters and attributes that are members of a datalist' do
           @representor_hash =  @base_representor.merge(@transition_elements)
           has_data_list = expect(subject.datalists.first.as_hash).to eq({renegade: "renegade", compliant: "compliant"})
         end
       end
-    end       
+    end
   end
 end

--- a/spec/lib/crichton/transition_spec.rb
+++ b/spec/lib/crichton/transition_spec.rb
@@ -42,27 +42,27 @@ module Crichton
           }
         }
     end
-    
+
     let(:representor_hash) { @representor_hash || @self_transition }
-    let(:subject) { Transition.new(representor_hash) }   
-    
+    let(:subject) { Transition.new(representor_hash) }
+
     describe '.new' do
       it 'returns a Crichton::Transition instance' do
         expect(subject).to be_an_instance_of(Transition)
       end
-      
+
       describe '#rel' do
         it 'returns the transition key' do
           expect(subject.rel).to eq(:self)
         end
       end
-      
+
       describe '#interface_method' do
         it 'returns the uniform interface method' do
           expect(subject.interface_method).to eq('GET')
         end
       end
-      
+
       describe '#parameters' do
         it 'returns a list of fields representing the link parameters' do
           @representor_hash = @search_transition
@@ -70,14 +70,14 @@ module Crichton
           expect(field).to be_an_instance_of(Field)
         end
       end
-      
+
       describe '#attributes' do
         it 'returns a list of fields representing the link attributes' do
           @representor_hash = @search_transition
           field = subject.attributes.first
           expect(field).to be_an_instance_of(Field)
         end
-      end           
+      end
 
       describe '#meta_links' do
         it 'returns a list of Transitions' do
@@ -86,32 +86,32 @@ module Crichton
           expect(links).to be_true
         end
       end
-      
+
       describe '#uri' do
         it 'returns the bare link' do
           @representor_hash = @search_transition
           expect(subject.uri).to eq('/')
         end
       end
-      
+
       describe '#templated_uri' do
         it 'returns the link parameterized' do
           @representor_hash = @search_transition
           expect(subject.templated_uri).to eq('/{?name}')
         end
       end
-        
+
       describe '#templated?' do
         it 'returns true if #templated_uri != uri' do
           @representor_hash = @search_transition
           expect(subject.templated?).to be_true
         end
-        
+
         it 'returns false if #templated_uri == uri' do
           @representor_hash = @self_transition
           expect(subject.templated?).to be_false
         end
-      end       
-    end    
+      end
+    end
   end
 end


### PR DESCRIPTION
Automatically with a script. This is important because many editors automatically delete them so will create unnecessary noise.

There is no change in functionality in this PR.
