### PR TITLE
added a to_hash convenience method to transition

### DIFF
--- a/lib/representors/transition.rb
+++ b/lib/representors/transition.rb
@@ -27,6 +27,11 @@ module Representors
       @transition_hash.inspect
     end
 
+    # @return [Hash] useful in cucumber steps where the feature file provides a hash
+    def to_hash
+      Hash[@transition_hash.map{ |k, v| [k.to_s, v] }]
+    end
+
     # @return [String] The name of the Relationship
     def rel
       @transition_hash[REL_KEY]

--- a/spec/lib/representors/transition_spec.rb
+++ b/spec/lib/representors/transition_spec.rb
@@ -50,6 +50,48 @@ module Representors
       end
     end
 
+    describe '#to_hash' do
+      let(:hash_with_symbol_keys) do
+        {
+          href: 'some.niceplace.com/list',
+          rel: 'self'
+        }
+      end
+      let(:hash_with_string_keys) do
+        {
+          'href' => 'some.niceplace.com/list',
+          'rel' => 'self'
+        }
+      end
+      context 'the keys are strings' do
+        let(:representor_hash) {hash_with_string_keys}
+        it 'returns a hash with the keys as strings' do
+          expect(subject.to_hash).to eq(hash_with_string_keys)
+        end
+      end
+      context 'the keys are symbols' do
+        let(:representor_hash) {hash_with_symbol_keys}
+        it 'returns a hash with the keys as strings' do
+          expect(subject.to_hash).to eq(hash_with_string_keys)
+        end
+      end
+    end
+
+    describe '#[]' do
+      let(:representor_hash) { {key => value}}
+      let(:value) { 'http://www.dontknow.com'}
+      let(:key)  {'href'}
+
+      it 'retuns the value for the keys' do
+        expect(subject[key]).to eq(value)
+      end
+
+      it 'returns nil if the key is not in this transition' do
+        expect(subject['Ido not exists']).to be_nil
+      end
+
+    end
+
     describe '.new' do
       it 'returns a Representors::Transition instance' do
         expect(subject).to be_an_instance_of(Transition)


### PR DESCRIPTION
This is useful to be used in scenarios where we get a cucumber table with data to compare.
Also added specs for [] with it seems I forgot the last time , oops.

@chad-medi  @cabbott 
