### PR TITLE
This is to address a bug (?) 

### DIFF
--- a/lib/representors.rb
+++ b/lib/representors.rb
@@ -1,4 +1,5 @@
+require 'representors/representor_hash'
 require 'representors/representor'
 require 'representors/representor_builder'
-require 'representors/representor_hash'
+
 require 'representors/serialization'

--- a/lib/representors/representor_builder.rb
+++ b/lib/representors/representor_builder.rb
@@ -1,3 +1,4 @@
+require 'representors/representor_hash'
 module Representors
 
   ##


### PR DESCRIPTION
found during the attempt to integrate with Crichton.  For some reason representor_builder needed representor_hash to be required.  Identical use is foudn in the builder spec without reproing the error - I cn only find the error when referencing it through Crichton, so I'm not sure how to confirm the test.  Also the behavior seems strange since /lib/representors 'requires' all the files and they are in the same module, so this behavior seems inexplicable to me.
