### PR TITLE
remove unused data method

### DIFF
--- a/lib/representors/transition.rb
+++ b/lib/representors/transition.rb
@@ -101,11 +101,6 @@ module Representors
       @descriptions ||= (attributes + parameters)
     end
 
-
-    def data
-      retrieve('data') || {}
-    end
-
     private
 
     # accept retrieving keys by symbol or string


### PR DESCRIPTION
Talked with @sheavalentine-mdsol about this, PR removes undocumented unused ``data` method from transition.

```
Finished in 0.38085 seconds
289 examples, 0 failures

Randomized with seed 35319
```
