### PR TITLE
[MCC-125061] refactor to move assignments out of conditional

### DIFF
--- a/lib/representors/representor.rb
+++ b/lib/representors/representor.rb
@@ -126,8 +126,10 @@ module Representors
     def embedded_transitions_hashes
       @representor_hash.embedded.flat_map do |k,*v|
         v.flatten.map do |item|
-          if trans_hash = item[:transitions].find { |t| t[:rel] == "self" }
-            trans_hash.merge(prop_hash) if prop_hash = item[:transitions].find { |t| t[:rel] == "profile" }
+          trans_hash = item[:transitions].find { |t| t[:rel] == "self" }
+          if trans_hash
+            prop_hash = item[:transitions].find { |t| t[:rel] == "profile" }
+            trans_hash.merge(prop_hash) if prop_hash
             trans_hash.merge(rel: k)
           else
             {}


### PR DESCRIPTION
moving the assignments out of the conditionals, per style guide.  Also apparently blowing up with 1.9 versions of ruby.

```
Finished in 1.72 seconds
322 examples, 0 failures, 1 pending

Randomized with seed 41706
```
