### PR TITLE
[MCC-125082] add yardoc for hale deserializer

### DIFF
--- a/lib/representors/serialization/hale_deserializer.rb
+++ b/lib/representors/serialization/hale_deserializer.rb
@@ -2,7 +2,8 @@ require 'representor_support/utilities'
 require 'representors/serialization/hal_deserializer'
 
 module Representors
-  # Class for a Hale document deserializer.  Built against Hale version 0.0.1
+  # Class for a Hale document deserializer.
+  # Built against Hale version 0.0.1, https://github.com/mdsol/hale/tree/0-0-stable
   # @since 0.0.2
   class HaleDeserializer < HalDeserializer
     media_symbol :hale


### PR DESCRIPTION
Adds yardoc to the hale deserializer specifying the hale version.  
