### PR TITLE
Serialize Empty Response Bodies

### DIFF
--- a/lib/representors/representor.rb
+++ b/lib/representors/representor.rb
@@ -32,6 +32,14 @@ module Representors
       SerializerFactory.build(format, self).to_media_type(options)
     end
 
+    def empty?
+      @representor_hash.empty?
+    end
+
+    def ==(other)
+      other.is_a?(Hash) ? to_hash == other : to_hash == other.to_hash
+    end
+
     # Returns the document for the representor
     #
     # @return [String] the document for the representor

--- a/lib/representors/representor_hash.rb
+++ b/lib/representors/representor_hash.rb
@@ -47,5 +47,13 @@ module Representors
       members.each_with_object({}) { |member, hash| hash[member] = self[member] }
     end
 
+    def empty?
+      members.all? { |k| self[k].nil? || self[k].empty? }
+    end
+
+    def ==(other)
+      members.all? { |k| self[k] == other[k] }
+    end
+
   end
 end

--- a/lib/representors/serialization/deserializer_base.rb
+++ b/lib/representors/serialization/deserializer_base.rb
@@ -4,6 +4,10 @@ require 'representors/serialization/deserializer_factory'
 module Representors
   class DeserializerBase < SerializationBase
 
+    def initialize(target)
+      @target = target.empty? ? {} : target
+    end
+
     def self.inherited(subclass)
       DeserializerFactory.register_deserializers(subclass)
     end

--- a/lib/representors/serialization/serialization_base.rb
+++ b/lib/representors/serialization/serialization_base.rb
@@ -6,10 +6,6 @@ module Representors
 
     attr_reader :target
 
-    def initialize(target)
-      @target = target
-    end
-
     def self.media_symbols
       @media_symbols ||= Set.new
     end

--- a/lib/representors/serialization/serializer_base.rb
+++ b/lib/representors/serialization/serializer_base.rb
@@ -3,6 +3,11 @@ require 'representors/serialization/serializer_factory'
 
 module Representors
   class SerializerBase < SerializationBase
+
+    def initialize(target)
+      @target = target.empty? ? Representor.new({}) : target
+    end
+
     def self.inherited(subclass)
       SerializerFactory.register_serializers(subclass)
     end

--- a/spec/lib/representors/serialization/deserializer_factory_spec.rb
+++ b/spec/lib/representors/serialization/deserializer_factory_spec.rb
@@ -44,7 +44,7 @@ module Representors
           expect(deserializer.to_representor_hash).to eq(RepresentorHash.new)
         end
       end
-      
+
       shared_examples_for 'a hal deserializer' do
         it 'returns a HalDeserializer' do
           expect(deserializer).to be_instance_of HalDeserializer
@@ -52,7 +52,18 @@ module Representors
 
         it_behaves_like 'a built deserializer'
       end
-      
+
+      context 'with an empty response body' do
+        [nil, '', '{}', ' '].each do |response_body|
+          context "when given a #{response_body.inspect}" do
+            let(:media_type) { 'application/hal+json' }
+            let(:document) { '' }
+
+            it_behaves_like 'a hal deserializer'
+          end
+        end
+      end
+
       context 'with hal+json media type as a string' do
         let(:media_type) { 'application/hal+json' }
 
@@ -84,7 +95,7 @@ module Representors
 
         it_behaves_like 'a hale deserializer'
       end
-      
+
       shared_examples_for 'an unknown media type' do
         it 'raises an unknown media type error' do
           expect { deserializer }.to raise_error(UnknownMediaTypeError, "Unknown media-type: #{media_type}.")
@@ -93,7 +104,7 @@ module Representors
 
       context 'unknown media type string' do
         let(:media_type) { 'unknown' }
-        
+
         it_behaves_like 'an unknown media type'
       end
 


### PR DESCRIPTION
With the goal in mind of being able to serialize empty response bodies, this change adds two other features to representor.  It allows one to determine if a representor or a representor hash is empty, and additionally allows one to determine equality of two representors.

Changes:
Added test for serializing empty responses.
Moved initializers out on serialization base and into deserializer_base and serializer_base to handle appropriate return types.
Added empty and equality methods to representor_hash and representor

TODO: Add equlity comparisons to field and transition objects.

All specs pass - will report on Crichton or Farscape regressions soon, though none are expected.
