### PR TITLE
version 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.5
+* Sync changes from the develop branch that had not been ported back to 0-0-stable (see PR #52 and PR #53)
+
 # 0.0.4
 * Updates and clean ups
 * Remove support of Ruby < 2.1

--- a/lib/representors/version.rb
+++ b/lib/representors/version.rb
@@ -1,4 +1,4 @@
 # Used to prevent the class/module from being loaded more than once
 module Representors
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
> Sync changes from the develop branch that had not been ported back to 0-0-stable (see PR #52 and PR #53)

This is needed because v0.0.4 from 0-0-stable was missing those changes. Leaving it as is would be confusing as to what is actually v0.0.4.

@mdsol/team-10 
