### PR TITLE
Ensure security patch for yard

### DIFF
--- a/representors.gemspec
+++ b/representors.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redcarpet', '~> 3.3'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov', '~> 0.11'
-  s.add_development_dependency 'yard', '~> 0.8'
+  s.add_development_dependency 'yard', '>= 0.9.11', '~> 0.9'
 end


### PR DESCRIPTION
Insist on using a version of Yard that doesn't have an arbitrary path traversal vulnerability. No need to panic unless you're for some reason allowing untrusted users to run yard with arbitrary flags (why?), but updating this clears Github's warning so it's good hygiene. Thanks to @mtanasie for the catch.